### PR TITLE
Updating to Bevy 0.14

### DIFF
--- a/bevy_examples/Cargo.toml
+++ b/bevy_examples/Cargo.toml
@@ -8,15 +8,15 @@ exclude = ["assets/"]
 [dependencies]
 # ----- Internal dependencies
 bevy_ghx_proc_gen = { path = "../bevy_ghx_proc_gen", default-features = true }
-bevy_ghx_utils = { version = "0.3.0", default-features = true }
+bevy_ghx_utils = { version = "0.4", default-features = true }
 
 # ----- External dependencies
 tracing-subscriber = "0.3.18"
 rand = "0.8.5"
-bevy = { version = "0.13.0", default-features = false, features = [
+bevy = { version = "0.14", default-features = false, features = [
 	# Default features:
 
-	"multi-threaded",     # Run with multithreading
+	"multi_threaded",     # Run with multithreading
 	"bevy_asset",         # Assets management
 	"bevy_scene",         # Scenes management
 	"bevy_render",        # Rendering framework core
@@ -43,7 +43,7 @@ bevy = { version = "0.13.0", default-features = false, features = [
 	# Development/Debug features:
 	"dynamic_linking", # Dynamic linking for faster compile-times
 ] }
-bevy_mod_picking = { version = "0.18.0", default-features = false, features = [
+bevy_mod_picking = { version = "0.20.0", default-features = false, features = [
 	"backend_raycast",
 	"backend_bevy_ui",
 	"backend_sprite",

--- a/bevy_examples/canyon/canyon.rs
+++ b/bevy_examples/canyon/canyon.rs
@@ -60,11 +60,6 @@ fn setup_scene(mut commands: Commands) {
     let look_target = Vec3::new(0., -10., 0.);
     let radius = (look_target - camera_position).length();
     commands.spawn((
-        Camera3dBundle {
-            transform: Transform::from_translation(camera_position)
-                .looking_at(look_target, Vec3::Y),
-            ..default()
-        },
         PanOrbitCameraBundle {
             state: PanOrbitState {
             radius,

--- a/bevy_examples/canyon/canyon.rs
+++ b/bevy_examples/canyon/canyon.rs
@@ -1,9 +1,11 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    log::LogPlugin, pbr::DirectionalLightShadowMap,
-     prelude::*,
-    color::palettes::css::{ORANGE_RED, GRAY}};
+    color::palettes::css::{GRAY, ORANGE_RED},
+    log::LogPlugin,
+    pbr::DirectionalLightShadowMap,
+    prelude::*,
+};
 
 use bevy_examples::{
     anim::SpawningScaleAnimation, plugin::ProcGenExamplesPlugin, utils::load_assets,
@@ -59,15 +61,18 @@ fn setup_scene(mut commands: Commands) {
     let camera_position = Vec3::new(0., 1.5 * GRID_HEIGHT as f32, 1.5 * GRID_Z as f32 / 2.);
     let look_target = Vec3::new(0., -10., 0.);
     let radius = (look_target - camera_position).length();
-    commands.spawn((
-        PanOrbitCameraBundle {
-            state: PanOrbitState {
+    commands.spawn((PanOrbitCameraBundle {
+        camera: Camera3dBundle {
+            transform: Transform::from_translation(camera_position)
+                .looking_at(look_target, Vec3::Y),
+            ..default()
+        },
+        state: PanOrbitState {
             radius,
             ..default()
         },
-            ..Default::default()
-        },
-    ));
+        ..Default::default()
+    },));
 
     // Scene lights
     commands.insert_resource(AmbientLight {

--- a/bevy_examples/canyon/canyon.rs
+++ b/bevy_examples/canyon/canyon.rs
@@ -13,7 +13,7 @@ use bevy_examples::{
 use bevy_ghx_proc_gen::{
     bevy_ghx_grid::{
         debug_plugin::{view::DebugGridView, DebugGridView3dBundle},
-        ghx_grid::cartesian::{coordinates::Cartesian3D, grid::CartesianGrid},
+        ghx_grid::{cartesian::{coordinates::Cartesian3D, grid::CartesianGrid}, grid::GridData},
     },
     gen::{
         assets::AssetSpawner,
@@ -126,7 +126,11 @@ fn setup_generator(mut commands: Commands, asset_server: Res<AssetServer>) {
         .unwrap();
     let grid = CartesianGrid::new_cartesian_3d(GRID_X, GRID_HEIGHT, GRID_Z, false, false, false);
 
-    let mut initial_constraints = grid.new_grid_data(None);
+    let grid_size = (grid.size_xy() * grid.size_z()) as usize;
+
+
+    //let mut initial_constraints = grid.new_grid_data(None);
+    let mut initial_constraints: GridData<Cartesian3D, _, CartesianGrid<Cartesian3D>> = GridData::new(grid.clone(), vec![None; grid_size]);
     // Force void nodes on the upmost layer
     let void_ref = Some(void_instance);
     initial_constraints.set_all_y(GRID_HEIGHT - 1, void_ref);

--- a/bevy_examples/canyon/rules.rs
+++ b/bevy_examples/canyon/rules.rs
@@ -1,7 +1,7 @@
 use bevy::{ecs::component::Component, math::Vec3};
 use bevy_examples::utils::AssetDef;
 use bevy_ghx_proc_gen::{
-    bevy_ghx_grid::ghx_grid::{coordinate_system::Cartesian3D, direction::GridDelta},
+    bevy_ghx_grid::ghx_grid::cartesian::coordinates::{Cartesian3D, GridDelta},
     gen::assets::ComponentSpawner,
     proc_gen::generator::{
         model::{ModelCollection, ModelInstance, ModelRotation},

--- a/bevy_examples/chessboard/chessboard.rs
+++ b/bevy_examples/chessboard/chessboard.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 use bevy_ghx_proc_gen::{
-    bevy_ghx_grid::ghx_grid::cartesian::{grid::CartesianGrid, coordinates::Cartesian2D},
+    bevy_ghx_grid::ghx_grid::cartesian::{coordinates::Cartesian2D, grid::CartesianGrid},
     gen::{
         assets::{AssetSpawner, RulesModelsAssets},
         default_bundles::PbrMesh,

--- a/bevy_examples/chessboard/chessboard.rs
+++ b/bevy_examples/chessboard/chessboard.rs
@@ -1,10 +1,7 @@
 use bevy::prelude::*;
 
 use bevy_ghx_proc_gen::{
-    bevy_ghx_grid::ghx_grid::{
-        coordinate_system::Cartesian2D,
-        grid::{GridDefinition, GridPosition},
-    },
+    bevy_ghx_grid::ghx_grid::cartesian::{grid::CartesianGrid, coordinates::Cartesian2D},
     gen::{
         assets::{AssetSpawner, RulesModelsAssets},
         default_bundles::PbrMesh,
@@ -65,14 +62,15 @@ fn setup_generator(
         .unwrap();
 
     // Like a chess board, let's do an 8x8 2d grid
-    let grid = GridDefinition::new_cartesian_2d(8, 8, false, false);
+    let grid = CartesianGrid::new_cartesian_2d(8, 8, false, false);
+    let initial_nodes = vec![(grid.index_from_coords(0, 0, 0), black_model)];
 
     // There many more parameters you can tweak on a Generator before building it, explore the API.
     let generator = GeneratorBuilder::new()
         .with_rules(rules)
         .with_grid(grid.clone())
         // Let's ensure that we make a chessboard, with a black square bottom-left
-        .with_initial_nodes(vec![(GridPosition::new_xy(0, 0), black_model)])
+        .with_initial_nodes(initial_nodes)
         .unwrap()
         .build()
         .unwrap();

--- a/bevy_examples/pillars/pillars.rs
+++ b/bevy_examples/pillars/pillars.rs
@@ -1,13 +1,17 @@
 use std::{f32::consts::PI, sync::Arc};
 
-use bevy::{log::LogPlugin, pbr::DirectionalLightShadowMap, prelude::*};
+use bevy::{
+    log::LogPlugin, pbr::DirectionalLightShadowMap,
+    prelude::*,
+    color::palettes::{basic::GRAY, css::ORANGE_RED}
+};
 
 use bevy_examples::{plugin::ProcGenExamplesPlugin, utils::load_assets};
 
 use bevy_ghx_proc_gen::{
     bevy_ghx_grid::{
         debug_plugin::{view::DebugGridView, DebugGridView3dBundle},
-        ghx_grid::{coordinate_system::Cartesian3D, grid::GridDefinition},
+        ghx_grid::cartesian::{coordinates::Cartesian3D, grid::CartesianGrid},
     },
     gen::{
         assets::{AssetSpawner, RulesModelsAssets},
@@ -16,7 +20,7 @@ use bevy_ghx_proc_gen::{
     proc_gen::generator::{builder::GeneratorBuilder, rules::RulesBuilder},
     GeneratorBundle,
 };
-use bevy_ghx_utils::camera::{update_pan_orbit_camera, PanOrbitCamera};
+use bevy_ghx_utils::camera::{update_pan_orbit_camera, PanOrbitCameraBundle, PanOrbitState};
 
 use crate::rules::rules_and_assets;
 
@@ -52,12 +56,15 @@ fn setup_scene(
             transform: Transform::from_translation(camera_position).looking_at(Vec3::ZERO, Vec3::Y),
             ..default()
         },
-        PanOrbitCamera {
-            radius,
-            ..Default::default()
+        PanOrbitCameraBundle {
+            state: PanOrbitState {
+                radius,
+                ..default()
+            },
+            ..default()
         },
         FogSettings {
-            color: Color::rgba(0.2, 0.15, 0.1, 1.0),
+            color: Color::srgba(0.2, 0.15, 0.1, 1.0).into(),
             falloff: FogFalloff::Linear {
                 start: 55.0,
                 end: 145.0,
@@ -69,7 +76,7 @@ fn setup_scene(
         PbrBundle {
             mesh: meshes.add(Mesh::from(Plane3d::default())),
             material: materials.add(StandardMaterial {
-                base_color: Color::hex("888888").unwrap(),
+                base_color: Color::srgb_u8(136, 136, 136).into(),
                 ..default()
             }),
             transform: Transform::from_scale(Vec3::splat(10000.0)).with_translation(Vec3::new(
@@ -84,14 +91,14 @@ fn setup_scene(
 
     // Scene lights
     commands.insert_resource(AmbientLight {
-        color: Color::ORANGE_RED,
+        color: ORANGE_RED.into(),
         brightness: 0.05,
     });
     commands.spawn(DirectionalLightBundle {
         directional_light: DirectionalLight {
             shadows_enabled: true,
             illuminance: 3000.,
-            color: Color::rgb(1.0, 0.85, 0.65),
+            color: Color::srgb(1.0, 0.85, 0.65).into(),
             ..default()
         },
         transform: Transform {
@@ -105,7 +112,7 @@ fn setup_scene(
         directional_light: DirectionalLight {
             shadows_enabled: false,
             illuminance: 1250.,
-            color: Color::rgb(1.0, 0.85, 0.65),
+            color: Color::srgb(1.0, 0.85, 0.65).into(),
             ..default()
         },
         transform: Transform {
@@ -126,7 +133,7 @@ fn setup_generator(mut commands: Commands, asset_server: Res<AssetServer>) {
             .build()
             .unwrap(),
     );
-    let grid = GridDefinition::new_cartesian_3d(GRID_X, GRID_HEIGHT, GRID_Z, false, false, false);
+    let grid = CartesianGrid::new_cartesian_3d(GRID_X, GRID_HEIGHT, GRID_Z, false, false, false);
     let gen_builder = GeneratorBuilder::new()
         // We share the Rules between all the generators
         .with_shared_rules(rules.clone())
@@ -160,7 +167,7 @@ fn setup_generator(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             observer,
             DebugGridView3dBundle {
-                view: DebugGridView::new(false, true, Color::GRAY, NODE_SIZE),
+                view: DebugGridView::new(false, true, GRAY.into(), NODE_SIZE),
                 ..default()
             },
             Name::new(format!("Grid_{}", i)),

--- a/bevy_examples/pillars/pillars.rs
+++ b/bevy_examples/pillars/pillars.rs
@@ -52,10 +52,6 @@ fn setup_scene(
     let camera_position = Vec3::new(0., 3. * GRID_HEIGHT as f32, 0.75 * GRID_Z as f32);
     let radius = camera_position.length();
     commands.spawn((
-        Camera3dBundle {
-            transform: Transform::from_translation(camera_position).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
         PanOrbitCameraBundle {
             state: PanOrbitState {
                 radius,

--- a/bevy_examples/pillars/pillars.rs
+++ b/bevy_examples/pillars/pillars.rs
@@ -1,9 +1,10 @@
 use std::{f32::consts::PI, sync::Arc};
 
 use bevy::{
-    log::LogPlugin, pbr::DirectionalLightShadowMap,
+    color::palettes::{basic::GRAY, css::ORANGE_RED},
+    log::LogPlugin,
+    pbr::DirectionalLightShadowMap,
     prelude::*,
-    color::palettes::{basic::GRAY, css::ORANGE_RED}
 };
 
 use bevy_examples::{plugin::ProcGenExamplesPlugin, utils::load_assets};
@@ -53,6 +54,10 @@ fn setup_scene(
     let radius = camera_position.length();
     commands.spawn((
         PanOrbitCameraBundle {
+            camera: Camera3dBundle {
+                transform: Transform::from_translation(camera_position).looking_at(Vec3::ZERO, Vec3::Y),
+                ..default()
+            },
             state: PanOrbitState {
                 radius,
                 ..default()

--- a/bevy_examples/pillars/rules.rs
+++ b/bevy_examples/pillars/rules.rs
@@ -1,6 +1,6 @@
 use bevy_examples::utils::AssetDef;
 use bevy_ghx_proc_gen::{
-    bevy_ghx_grid::ghx_grid::coordinate_system::Cartesian3D,
+    bevy_ghx_grid::ghx_grid::cartesian::coordinates::Cartesian3D,
     proc_gen::generator::{
         model::ModelCollection,
         socket::{SocketCollection, SocketsCartesian3D},

--- a/bevy_examples/src/fps.rs
+++ b/bevy_examples/src/fps.rs
@@ -1,5 +1,6 @@
 use bevy::{
     app::{App, Plugin, Startup, Update},
+    color::{Color, palettes::basic::{WHITE, BLACK}},
     diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
     ecs::{
         component::Component,
@@ -7,7 +8,8 @@ use bevy::{
         system::{Commands, Query, Res},
     },
     hierarchy::BuildChildren,
-    render::{color::Color, view::Visibility},
+    prelude::Alpha,
+    render::view::Visibility,
     text::{Text, TextSection, TextStyle},
     ui::{
         node_bundles::{NodeBundle, TextBundle},
@@ -45,7 +47,7 @@ pub fn setup_fps_counter(mut commands: Commands) {
             FpsRoot,
             NodeBundle {
                 // give it a dark background for readability
-                background_color: BackgroundColor(Color::BLACK.with_a(0.5)),
+                background_color: BackgroundColor(BLACK.with_alpha(0.5).into()),
                 // make it "always on top" by setting the Z index to maximum
                 // we want it to be displayed over all other UI
                 z_index: ZIndex::Global(i32::MAX),
@@ -79,7 +81,7 @@ pub fn setup_fps_counter(mut commands: Commands) {
                         value: "FPS: ".into(),
                         style: TextStyle {
                             font_size: DEFAULT_EXAMPLES_FONT_SIZE,
-                            color: Color::WHITE,
+                            color: WHITE.into(),
                             // if you want to use your game's font asset,
                             // uncomment this and provide the handle:
                             // font: my_font_handle
@@ -90,7 +92,7 @@ pub fn setup_fps_counter(mut commands: Commands) {
                         value: " N/A".into(),
                         style: TextStyle {
                             font_size: DEFAULT_EXAMPLES_FONT_SIZE,
-                            color: Color::WHITE,
+                            color: WHITE.into(),
                             // if you want to use your game's font asset,
                             // uncomment this and provide the handle:
                             // font: my_font_handle
@@ -124,22 +126,22 @@ pub fn fps_text_update_system(
             // text according to the FPS value:
             text.sections[1].style.color = if value >= 120.0 {
                 // Above 120 FPS, use green color
-                Color::rgb(0.0, 1.0, 0.0)
+                Color::srgb(0.0, 1.0, 0.0)
             } else if value >= 60.0 {
                 // Between 60-120 FPS, gradually transition from yellow to green
-                Color::rgb((1.0 - (value - 60.0) / (120.0 - 60.0)) as f32, 1.0, 0.0)
+                Color::srgb((1.0 - (value - 60.0) / (120.0 - 60.0)) as f32, 1.0, 0.0)
             } else if value >= 30.0 {
                 // Between 30-60 FPS, gradually transition from red to yellow
-                Color::rgb(1.0, ((value - 30.0) / (60.0 - 30.0)) as f32, 0.0)
+                Color::srgb(1.0, ((value - 30.0) / (60.0 - 30.0)) as f32, 0.0)
             } else {
                 // Below 30 FPS, use red color
-                Color::rgb(1.0, 0.0, 0.0)
+                Color::srgb(1.0, 0.0, 0.0)
             }
         } else {
             // display "N/A" if we can't get a FPS measurement
             // add an extra space to preserve alignment
             text.sections[1].value = " N/A".into();
-            text.sections[1].style.color = Color::WHITE;
+            text.sections[1].style.color = WHITE.into();
         }
     }
 }

--- a/bevy_examples/src/fps.rs
+++ b/bevy_examples/src/fps.rs
@@ -1,6 +1,9 @@
 use bevy::{
     app::{App, Plugin, Startup, Update},
-    color::{Color, palettes::basic::{WHITE, BLACK}},
+    color::{
+        palettes::basic::{BLACK, WHITE},
+        Color,
+    },
     diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
     ecs::{
         component::Component,

--- a/bevy_examples/src/plugin.rs
+++ b/bevy_examples/src/plugin.rs
@@ -2,7 +2,10 @@ use std::marker::PhantomData;
 
 use bevy::{
     app::{App, Plugin, PreUpdate, Startup, Update},
-    color::{Color, palettes::css::{YELLOW_GREEN, GREEN}},
+    color::{
+        palettes::css::{GREEN, YELLOW_GREEN},
+        Color,
+    },
     diagnostic::FrameTimeDiagnosticsPlugin,
     ecs::{
         component::Component,
@@ -34,7 +37,9 @@ use bevy_ghx_proc_gen::{
             markers::MarkersGroup, toggle_debug_grids_visibilities,
             toggle_grid_markers_visibilities, GridDebugPlugin,
         },
-        ghx_grid::{coordinate_system::CoordinateSystem, cartesian::coordinates::CartesianCoordinates},
+        ghx_grid::{
+            cartesian::coordinates::CartesianCoordinates, coordinate_system::CoordinateSystem,
+        },
     },
     gen::{
         assets::{AssetsBundleSpawner, ComponentSpawner, NoComponents},

--- a/bevy_examples/src/plugin.rs
+++ b/bevy_examples/src/plugin.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use bevy::{
     app::{App, Plugin, PreUpdate, Startup, Update},
+    color::{Color, palettes::css::{YELLOW_GREEN, GREEN}},
     diagnostic::FrameTimeDiagnosticsPlugin,
     ecs::{
         component::Component,
@@ -19,8 +20,7 @@ use bevy::{
         ButtonInput,
     },
     math::Vec3,
-    prelude::default,
-    render::color::Color,
+    prelude::{default, Alpha},
     text::{BreakLineOn, Text, TextSection, TextStyle},
     ui::{
         node_bundles::{NodeBundle, TextBundle},
@@ -34,7 +34,7 @@ use bevy_ghx_proc_gen::{
             markers::MarkersGroup, toggle_debug_grids_visibilities,
             toggle_grid_markers_visibilities, GridDebugPlugin,
         },
-        ghx_grid::coordinate_system::CoordinateSystem,
+        ghx_grid::{coordinate_system::CoordinateSystem, cartesian::coordinates::CartesianCoordinates},
     },
     gen::{
         assets::{AssetsBundleSpawner, ComponentSpawner, NoComponents},
@@ -80,7 +80,7 @@ impl<C: CoordinateSystem, A: AssetsBundleSpawner, T: ComponentSpawner>
 const DEFAULT_SPAWN_ANIMATION_DURATION: f32 = 0.6;
 const FAST_SPAWN_ANIMATION_DURATION: f32 = 0.1;
 
-impl<C: CoordinateSystem, A: AssetsBundleSpawner, T: ComponentSpawner> Plugin
+impl<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner> Plugin
     for ProcGenExamplesPlugin<C, A, T>
 {
     fn build(&self, app: &mut App) {
@@ -126,7 +126,7 @@ impl<C: CoordinateSystem, A: AssetsBundleSpawner, T: ComponentSpawner> Plugin
             PreUpdate,
             absorb_egui_inputs
                 .after(bevy_egui::systems::process_input_system)
-                .before(bevy_egui::EguiSet::BeginFrame),
+                .before(bevy_egui::EguiSet::BeginPass),
         );
     }
 }
@@ -197,7 +197,7 @@ pub fn setup_ui(mut commands: Commands, view_mode: Res<GenerationViewMode>) {
         .spawn((
             Pickable::IGNORE,
             NodeBundle {
-                background_color: Color::BLACK.with_a(0.6).into(),
+                background_color: Color::BLACK.with_alpha(0.6).into(),
                 style: Style {
                     position_type: PositionType::Absolute,
                     top: Val::Percent(1.),
@@ -298,9 +298,9 @@ pub fn update_generation_control_ui(
     for mut text in &mut query {
         let status_section = &mut text.sections[GENERATION_CONTROL_STATUS_TEXT_SECTION_ID];
         (status_section.value, status_section.style.color) = match gen_control.status {
-            GenerationControlStatus::Ongoing => ("Ongoing ('Space' to pause)".into(), Color::GREEN),
+            GenerationControlStatus::Ongoing => ("Ongoing ('Space' to pause)".into(), GREEN.into()),
             GenerationControlStatus::Paused => {
-                ("Paused ('Space' to unpause)".into(), Color::YELLOW_GREEN)
+                ("Paused ('Space' to unpause)".into(), YELLOW_GREEN.into())
             }
         };
 

--- a/bevy_examples/src/utils.rs
+++ b/bevy_examples/src/utils.rs
@@ -5,7 +5,7 @@ use bevy::{
 };
 
 use bevy_ghx_proc_gen::{
-    bevy_ghx_grid::ghx_grid::direction::GridDelta,
+    bevy_ghx_grid::ghx_grid::cartesian::coordinates::GridDelta,
     gen::assets::{
         AssetsBundleSpawner, ComponentSpawner, ModelAsset, NoComponents, RulesModelsAssets,
     },

--- a/bevy_examples/tile-layers/rules.rs
+++ b/bevy_examples/tile-layers/rules.rs
@@ -2,7 +2,7 @@ use bevy_examples::utils::AssetDef;
 
 use bevy_ghx_proc_gen::{
     bevy_ghx_grid::ghx_grid::{
-        cartesian::coordinates::{GridDelta, Cartesian3D},
+        cartesian::coordinates::{Cartesian3D, GridDelta},
         direction::Direction,
     },
     proc_gen::generator::{

--- a/bevy_examples/tile-layers/rules.rs
+++ b/bevy_examples/tile-layers/rules.rs
@@ -2,8 +2,8 @@ use bevy_examples::utils::AssetDef;
 
 use bevy_ghx_proc_gen::{
     bevy_ghx_grid::ghx_grid::{
-        coordinate_system::Cartesian3D,
-        direction::{Direction, GridDelta},
+        cartesian::coordinates::{GridDelta, Cartesian3D},
+        direction::Direction,
     },
     proc_gen::generator::{
         model::{ModelCollection, ModelRotation},

--- a/bevy_examples/tile-layers/tile-layers.rs
+++ b/bevy_examples/tile-layers/tile-layers.rs
@@ -1,15 +1,13 @@
 use bevy::{
     app::{App, PluginGroup, Startup},
     asset::{AssetServer, Handle},
+    color::Color,
     core_pipeline::core_2d::Camera2dBundle,
     ecs::system::{Commands, Res},
     log::LogPlugin,
     math::Vec3,
     prelude::SpatialBundle,
-    render::{
-        color::Color,
-        texture::{Image, ImagePlugin},
-    },
+    render::texture::{Image, ImagePlugin},
     transform::components::Transform,
     utils::default,
     DefaultPlugins,
@@ -19,7 +17,7 @@ use bevy_examples::{plugin::ProcGenExamplesPlugin, utils::load_assets};
 use bevy_ghx_proc_gen::{
     bevy_ghx_grid::{
         debug_plugin::{view::DebugGridView, DebugGridView2dBundle},
-        ghx_grid::{coordinate_system::Cartesian3D, direction::Direction, grid::GridDefinition},
+        ghx_grid::{cartesian::{grid::CartesianGrid, coordinates::Cartesian3D}, direction::Direction },
     },
     gen::{
         assets::{AssetSpawner, RulesModelsAssets},
@@ -74,7 +72,7 @@ fn setup_generator(mut commands: Commands, asset_server: Res<AssetServer>) {
         .with_rotation_axis(Direction::ZForward)
         .build()
         .unwrap();
-    let grid = GridDefinition::new_cartesian_3d(GRID_X, GRID_Y, GRID_Z, false, false, false);
+    let grid = CartesianGrid::new_cartesian_3d(GRID_X, GRID_Y, GRID_Z, false, false, false);
     let mut gen_builder = GeneratorBuilder::new()
         .with_rules(rules)
         .with_grid(grid.clone())

--- a/bevy_examples/tile-layers/tile-layers.rs
+++ b/bevy_examples/tile-layers/tile-layers.rs
@@ -17,7 +17,10 @@ use bevy_examples::{plugin::ProcGenExamplesPlugin, utils::load_assets};
 use bevy_ghx_proc_gen::{
     bevy_ghx_grid::{
         debug_plugin::{view::DebugGridView, DebugGridView2dBundle},
-        ghx_grid::{cartesian::{grid::CartesianGrid, coordinates::Cartesian3D}, direction::Direction },
+        ghx_grid::{
+            cartesian::{coordinates::Cartesian3D, grid::CartesianGrid},
+            direction::Direction,
+        },
     },
     gen::{
         assets::{AssetSpawner, RulesModelsAssets},

--- a/bevy_ghx_proc_gen/Cargo.toml
+++ b/bevy_ghx_proc_gen/Cargo.toml
@@ -47,15 +47,17 @@ ghx_proc_gen = { path = "../ghx_proc_gen", version = "0.2.0", features = [
 ] }
 
 # ----- External dependencies
-bevy = { version = "0.13.0", default-features = false, features = [
+bevy = { version = "0.14", default-features = false, features = [
     "bevy_render", # Rendering framework core
+    "bevy_winit",
+    "wayland", # Needed for some reason
 ] }
 
 # ----- Optional dependencies
-bevy_ghx_grid = { version = "0.2.1", optional = true, features = [] }
+bevy_ghx_grid = { version = "0.4", optional = true, features = [] }
 # Only enabled when the "picking" feature is enabled
-bevy_mod_picking = { version = "0.18.0", optional = true, default-features = false }
+bevy_mod_picking = { version = "0.20", optional = true, default-features = false }
 # Bevy_mod_picking depends on this version of bevy_egui
-bevy_egui = { version = "0.25.0", optional = true, default-features = false, features = [
+bevy_egui = { version = "0.30", optional = true, default-features = false, features = [
     "default_fonts",
 ] }

--- a/bevy_ghx_proc_gen/src/gen.rs
+++ b/bevy_ghx_proc_gen/src/gen.rs
@@ -9,8 +9,8 @@ use bevy::{
     hierarchy::BuildChildren,
     math::Vec3,
 };
-use bevy_ghx_grid::ghx_grid::{coordinate_system::CoordinateSystem, grid::GridDefinition};
-use ghx_proc_gen::{generator::model::ModelInstance, NodeIndex};
+use bevy_ghx_grid::ghx_grid::{coordinate_system::CoordinateSystem, cartesian::{grid::CartesianGrid, coordinates::GridDelta}};
+use ghx_proc_gen::{generator::model::ModelInstance, ghx_grid::cartesian::coordinates::CartesianCoordinates, NodeIndex};
 
 use self::assets::{AssetSpawner, AssetsBundleSpawner, ComponentSpawner};
 
@@ -112,10 +112,10 @@ pub fn insert_bundle_from_resource_to_spawned_nodes<B: Bundle + Resource + Clone
 /// ```ignore
 /// spawn_node::<Cartesian3D, Handle<Image>>(...);
 /// ```
-pub fn spawn_node<C: CoordinateSystem, A: AssetsBundleSpawner, T: ComponentSpawner>(
+pub fn spawn_node<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner>(
     commands: &mut Commands,
     gen_entity: Entity,
-    grid: &GridDefinition<C>,
+    grid: &CartesianGrid<C>,
     asset_spawner: &AssetSpawner<A, T>,
     instance: &ModelInstance,
     node_index: NodeIndex,

--- a/bevy_ghx_proc_gen/src/gen.rs
+++ b/bevy_ghx_proc_gen/src/gen.rs
@@ -9,8 +9,11 @@ use bevy::{
     hierarchy::BuildChildren,
     math::Vec3,
 };
-use bevy_ghx_grid::ghx_grid::{coordinate_system::CoordinateSystem, cartesian::{grid::CartesianGrid, coordinates::GridDelta}};
-use ghx_proc_gen::{generator::model::ModelInstance, ghx_grid::cartesian::coordinates::CartesianCoordinates, NodeIndex};
+use bevy_ghx_grid::ghx_grid::cartesian::{coordinates::GridDelta, grid::CartesianGrid};
+use ghx_proc_gen::{
+    generator::model::ModelInstance, ghx_grid::cartesian::coordinates::CartesianCoordinates,
+    NodeIndex,
+};
 
 use self::assets::{AssetSpawner, AssetsBundleSpawner, ComponentSpawner};
 
@@ -112,7 +115,7 @@ pub fn insert_bundle_from_resource_to_spawned_nodes<B: Bundle + Resource + Clone
 /// ```ignore
 /// spawn_node::<Cartesian3D, Handle<Image>>(...);
 /// ```
-pub fn spawn_node<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner>(
+pub fn spawn_node<C: CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner>(
     commands: &mut Commands,
     gen_entity: Entity,
     grid: &CartesianGrid<C>,

--- a/bevy_ghx_proc_gen/src/gen/assets.rs
+++ b/bevy_ghx_proc_gen/src/gen/assets.rs
@@ -4,11 +4,11 @@ use std::{
     sync::Arc,
 };
 
+use crate::gen::GridDelta;
 use bevy::{
     ecs::{component::Component, system::EntityCommands},
     math::Vec3,
 };
-use crate::gen::GridDelta;
 use ghx_proc_gen::generator::model::{ModelIndex, ModelRotation};
 
 /// Defines a struct which can spawn an assets [`bevy::prelude::Bundle`] (for example, a [`bevy::prelude::SpriteBundle`], a [`bevy::prelude::PbrBundle`], a [`bevy::prelude::SceneBundle`], ...).

--- a/bevy_ghx_proc_gen/src/gen/assets.rs
+++ b/bevy_ghx_proc_gen/src/gen/assets.rs
@@ -8,7 +8,7 @@ use bevy::{
     ecs::{component::Component, system::EntityCommands},
     math::Vec3,
 };
-use bevy_ghx_grid::ghx_grid::direction::GridDelta;
+use crate::gen::GridDelta;
 use ghx_proc_gen::generator::model::{ModelIndex, ModelRotation};
 
 /// Defines a struct which can spawn an assets [`bevy::prelude::Bundle`] (for example, a [`bevy::prelude::SpriteBundle`], a [`bevy::prelude::PbrBundle`], a [`bevy::prelude::SceneBundle`], ...).

--- a/bevy_ghx_proc_gen/src/gen/debug_plugin.rs
+++ b/bevy_ghx_proc_gen/src/gen/debug_plugin.rs
@@ -1,15 +1,14 @@
-use std::{marker::PhantomData, time::Duration};
 use crate::gen::CartesianCoordinates;
+use std::{marker::PhantomData, time::Duration};
 
 use bevy::{
     app::{App, Plugin, PostStartup, PostUpdate, PreUpdate, Startup, Update},
+    color::Color,
     ecs::{schedule::IntoSystemConfigs, system::Resource},
     input::keyboard::KeyCode,
-    color::Color,
-    time::{Timer, TimerMode},
     prelude::Alpha,
+    time::{Timer, TimerMode},
 };
-use bevy_ghx_grid::ghx_grid::coordinate_system::CoordinateSystem;
 
 use self::{
     cursor::{
@@ -100,7 +99,7 @@ impl Default for GridCursorsUiSettings {
 ///
 /// It also uses the following `Resources`: [`ProcGenKeyBindings`] and [`GenerationControl`] (and will init them to their defaults if not inserted by the user).
 pub struct ProcGenDebugPlugin<
-    C: CoordinateSystem + CartesianCoordinates,
+    C: CartesianCoordinates,
     A: AssetsBundleSpawner,
     T: ComponentSpawner = NoComponents,
 > {
@@ -109,7 +108,9 @@ pub struct ProcGenDebugPlugin<
     typestate: PhantomData<(C, A, T)>,
 }
 
-impl<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner> ProcGenDebugPlugin<C, A, T> {
+impl<C: CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner>
+    ProcGenDebugPlugin<C, A, T>
+{
     /// Plugin constructor
     pub fn new(generation_view_mode: GenerationViewMode, cursor_ui_mode: CursorUiMode) -> Self {
         Self {
@@ -120,7 +121,7 @@ impl<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: Comp
     }
 }
 
-impl<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner> Plugin
+impl<C: CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner> Plugin
     for ProcGenDebugPlugin<C, A, T>
 {
     // TODO Clean: Split into multiple plugins

--- a/bevy_ghx_proc_gen/src/gen/debug_plugin.rs
+++ b/bevy_ghx_proc_gen/src/gen/debug_plugin.rs
@@ -1,11 +1,13 @@
 use std::{marker::PhantomData, time::Duration};
+use crate::gen::CartesianCoordinates;
 
 use bevy::{
     app::{App, Plugin, PostStartup, PostUpdate, PreUpdate, Startup, Update},
     ecs::{schedule::IntoSystemConfigs, system::Resource},
     input::keyboard::KeyCode,
-    render::color::Color,
+    color::Color,
     time::{Timer, TimerMode},
+    prelude::Alpha,
 };
 use bevy_ghx_grid::ghx_grid::coordinate_system::CoordinateSystem;
 
@@ -86,7 +88,7 @@ impl Default for GridCursorsUiSettings {
     fn default() -> Self {
         Self {
             font_size: 16.0,
-            background_color: Color::BLACK.with_a(0.45),
+            background_color: Color::BLACK.with_alpha(0.45),
             text_color: Color::WHITE,
         }
     }
@@ -98,7 +100,7 @@ impl Default for GridCursorsUiSettings {
 ///
 /// It also uses the following `Resources`: [`ProcGenKeyBindings`] and [`GenerationControl`] (and will init them to their defaults if not inserted by the user).
 pub struct ProcGenDebugPlugin<
-    C: CoordinateSystem,
+    C: CoordinateSystem + CartesianCoordinates,
     A: AssetsBundleSpawner,
     T: ComponentSpawner = NoComponents,
 > {
@@ -107,7 +109,7 @@ pub struct ProcGenDebugPlugin<
     typestate: PhantomData<(C, A, T)>,
 }
 
-impl<C: CoordinateSystem, A: AssetsBundleSpawner, T: ComponentSpawner> ProcGenDebugPlugin<C, A, T> {
+impl<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner> ProcGenDebugPlugin<C, A, T> {
     /// Plugin constructor
     pub fn new(generation_view_mode: GenerationViewMode, cursor_ui_mode: CursorUiMode) -> Self {
         Self {
@@ -118,7 +120,7 @@ impl<C: CoordinateSystem, A: AssetsBundleSpawner, T: ComponentSpawner> ProcGenDe
     }
 }
 
-impl<C: CoordinateSystem, A: AssetsBundleSpawner, T: ComponentSpawner> Plugin
+impl<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner> Plugin
     for ProcGenDebugPlugin<C, A, T>
 {
     // TODO Clean: Split into multiple plugins

--- a/bevy_ghx_proc_gen/src/gen/debug_plugin/cursor.rs
+++ b/bevy_ghx_proc_gen/src/gen/debug_plugin/cursor.rs
@@ -1,10 +1,8 @@
-use std::{fmt, time::Duration};
 use crate::gen::CartesianCoordinates;
-
+use std::{fmt, time::Duration};
 
 use bevy::{
     color::Color,
-    prelude::Srgba,
     core::Name,
     ecs::{
         component::Component,
@@ -16,6 +14,7 @@ use bevy::{
     hierarchy::BuildChildren,
     input::{keyboard::KeyCode, ButtonInput},
     log::warn,
+    prelude::Srgba,
     render::camera::Camera,
     text::{BreakLineOn, Text, TextSection, TextStyle},
     time::{Time, Timer, TimerMode},
@@ -29,9 +28,9 @@ use bevy::{
 use bevy_ghx_grid::{
     debug_plugin::markers::{spawn_marker, GridMarker, MarkerDespawnEvent},
     ghx_grid::{
+        cartesian::{coordinates::CartesianPosition, grid::CartesianGrid},
         coordinate_system::CoordinateSystem,
         direction::Direction,
-        cartesian::{grid::CartesianGrid, coordinates::CartesianPosition},
     },
 };
 use ghx_proc_gen::{

--- a/bevy_ghx_proc_gen/src/gen/debug_plugin/egui_editor.rs
+++ b/bevy_ghx_proc_gen/src/gen/debug_plugin/egui_editor.rs
@@ -1,3 +1,5 @@
+use crate::gen::CartesianCoordinates;
+
 use bevy::{
     ecs::{
         event::{Event, EventReader, EventWriter},
@@ -79,7 +81,7 @@ pub fn toggle_editor(mut editor_config: ResMut<EditorConfig>) {
 }
 
 /// System used to draw the editor egui window
-pub fn draw_edition_panel<C: CoordinateSystem>(
+pub fn draw_edition_panel<C: CoordinateSystem + CartesianCoordinates>(
     editor_context: ResMut<EditorContext>,
     mut contexts: EguiContexts,
     active_generation: Res<ActiveGeneration>,
@@ -251,7 +253,7 @@ pub fn update_painting_state(
 }
 
 /// System issuing the generation requests to the geenrator based on the painting state
-pub fn paint<C: CoordinateSystem>(
+pub fn paint<C: CoordinateSystem + CartesianCoordinates>(
     editor_context: ResMut<EditorContext>,
     active_generation: Res<ActiveGeneration>,
     mut node_over_events: EventReader<NodeOverEvent>,

--- a/bevy_ghx_proc_gen/src/gen/debug_plugin/generation.rs
+++ b/bevy_ghx_proc_gen/src/gen/debug_plugin/generation.rs
@@ -1,5 +1,5 @@
-use std::collections::HashSet;
 use crate::gen::CartesianCoordinates;
+use std::collections::HashSet;
 
 use bevy::{
     color::palettes::basic::RED,
@@ -18,7 +18,7 @@ use bevy::{
 };
 use bevy_ghx_grid::{
     debug_plugin::markers::{spawn_marker, MarkerDespawnEvent},
-    ghx_grid::{coordinate_system::CoordinateSystem, cartesian::grid::CartesianGrid},
+    ghx_grid::{cartesian::grid::CartesianGrid, coordinate_system::CoordinateSystem},
 };
 use ghx_proc_gen::{
     generator::{
@@ -296,7 +296,11 @@ pub fn step_by_step_timed_update<C: CoordinateSystem + CartesianCoordinates>(
 }
 
 /// System used to spawn nodes, emit [GenerationEvent] and despawn markers, based on data read from a [QueuedObserver] on a generation entity
-pub fn update_generation_view<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner>(
+pub fn update_generation_view<
+    C: CoordinateSystem + CartesianCoordinates,
+    A: AssetsBundleSpawner,
+    T: ComponentSpawner,
+>(
     mut commands: Commands,
     mut marker_events: EventWriter<MarkerDespawnEvent>,
     mut generation_events: EventWriter<GenerationEvent>,

--- a/bevy_ghx_proc_gen/src/gen/debug_plugin/picking.rs
+++ b/bevy_ghx_proc_gen/src/gen/debug_plugin/picking.rs
@@ -2,6 +2,7 @@ use crate::gen::CartesianCoordinates;
 
 use bevy::{
     asset::{Assets, Handle},
+    color::Color,
     ecs::{
         component::Component,
         entity::Entity,
@@ -13,9 +14,8 @@ use bevy::{
     input::{keyboard::KeyCode, ButtonInput},
     math::{primitives::Cuboid, Vec2, Vec3},
     pbr::{NotShadowCaster, PbrBundle, StandardMaterial},
-    prelude::{Deref, DerefMut, AlphaMode, Alpha},
+    prelude::{Alpha, AlphaMode, Deref, DerefMut},
     render::mesh::Mesh,
-    color::Color,
     sprite::{Sprite, SpriteBundle},
     text::Text,
     transform::components::Transform,
@@ -28,7 +28,9 @@ use bevy_ghx_grid::{
         markers::{GridMarker, MarkerDespawnEvent},
         view::{DebugGridView, DebugGridView2d, DebugGridView3d},
     },
-    ghx_grid::{coordinate_system::CoordinateSystem, direction::Direction, cartesian::grid::CartesianGrid},
+    ghx_grid::{
+        cartesian::grid::CartesianGrid, coordinate_system::CoordinateSystem, direction::Direction,
+    },
 };
 use bevy_mod_picking::{
     events::Out,

--- a/bevy_ghx_proc_gen/src/gen/simple_plugin.rs
+++ b/bevy_ghx_proc_gen/src/gen/simple_plugin.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use crate::gen::CartesianCoordinates;
 
 use bevy::{
     app::{App, Plugin, Update},
@@ -22,14 +23,14 @@ use super::{assets::NoComponents, AssetSpawner, AssetsBundleSpawner, ComponentSp
 ///
 /// Once the generation is successful, the plugin will spawn the generated nodes assets.
 pub struct ProcGenSimplePlugin<
-    C: CoordinateSystem,
+    C: CoordinateSystem + CartesianCoordinates,
     A: AssetsBundleSpawner,
     T: ComponentSpawner = NoComponents,
 > {
     typestate: PhantomData<(C, A, T)>,
 }
 
-impl<C: CoordinateSystem, A: AssetsBundleSpawner, T: ComponentSpawner> Plugin
+impl<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner> Plugin
     for ProcGenSimplePlugin<C, A, T>
 {
     fn build(&self, app: &mut App) {
@@ -41,7 +42,7 @@ impl<C: CoordinateSystem, A: AssetsBundleSpawner, T: ComponentSpawner> Plugin
     }
 }
 
-impl<C: CoordinateSystem, A: AssetsBundleSpawner, T: ComponentSpawner>
+impl<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner>
     ProcGenSimplePlugin<C, A, T>
 {
     /// Constructor
@@ -67,7 +68,7 @@ impl Default for PendingGenerations {
 }
 
 /// System used by [`ProcGenSimplePlugin`] to track entities with newly added [`Generator`] components
-pub fn register_new_generations<C: CoordinateSystem>(
+pub fn register_new_generations<C: CoordinateSystem + CartesianCoordinates>(
     mut pending_generations: ResMut<PendingGenerations>,
     mut new_generations: Query<Entity, Added<Generator<C>>>,
 ) {
@@ -77,7 +78,7 @@ pub fn register_new_generations<C: CoordinateSystem>(
 }
 
 /// System used by [`ProcGenSimplePlugin`] to run generators and spawn their node's assets
-pub fn generate_and_spawn<C: CoordinateSystem, A: AssetsBundleSpawner, T: ComponentSpawner>(
+pub fn generate_and_spawn<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner>(
     mut commands: Commands,
     mut pending_generations: ResMut<PendingGenerations>,
     mut generations: Query<(&mut Generator<C>, &AssetSpawner<A, T>)>,
@@ -94,7 +95,7 @@ pub fn generate_and_spawn<C: CoordinateSystem, A: AssetsBundleSpawner, T: Compon
                         generation.seed(),
                         generation.grid()
                     );
-                    for (node_index, node) in grid_data.nodes().iter().enumerate() {
+                    for (node_index, node) in grid_data.iter().enumerate() {
                         spawn_node(
                             &mut commands,
                             gen_entity,

--- a/bevy_ghx_proc_gen/src/gen/simple_plugin.rs
+++ b/bevy_ghx_proc_gen/src/gen/simple_plugin.rs
@@ -1,5 +1,5 @@
-use std::marker::PhantomData;
 use crate::gen::CartesianCoordinates;
+use std::marker::PhantomData;
 
 use bevy::{
     app::{App, Plugin, Update},
@@ -12,7 +12,6 @@ use bevy::{
     log::{info, warn},
     utils::HashSet,
 };
-use bevy_ghx_grid::ghx_grid::coordinate_system::CoordinateSystem;
 use ghx_proc_gen::{generator::Generator, GeneratorError};
 
 use crate::gen::spawn_node;
@@ -23,14 +22,14 @@ use super::{assets::NoComponents, AssetSpawner, AssetsBundleSpawner, ComponentSp
 ///
 /// Once the generation is successful, the plugin will spawn the generated nodes assets.
 pub struct ProcGenSimplePlugin<
-    C: CoordinateSystem + CartesianCoordinates,
+    C: CartesianCoordinates,
     A: AssetsBundleSpawner,
     T: ComponentSpawner = NoComponents,
 > {
     typestate: PhantomData<(C, A, T)>,
 }
 
-impl<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner> Plugin
+impl<C: CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner> Plugin
     for ProcGenSimplePlugin<C, A, T>
 {
     fn build(&self, app: &mut App) {
@@ -42,7 +41,7 @@ impl<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: Comp
     }
 }
 
-impl<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner>
+impl<C: CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner>
     ProcGenSimplePlugin<C, A, T>
 {
     /// Constructor
@@ -68,7 +67,7 @@ impl Default for PendingGenerations {
 }
 
 /// System used by [`ProcGenSimplePlugin`] to track entities with newly added [`Generator`] components
-pub fn register_new_generations<C: CoordinateSystem + CartesianCoordinates>(
+pub fn register_new_generations<C: CartesianCoordinates>(
     mut pending_generations: ResMut<PendingGenerations>,
     mut new_generations: Query<Entity, Added<Generator<C>>>,
 ) {
@@ -78,7 +77,7 @@ pub fn register_new_generations<C: CoordinateSystem + CartesianCoordinates>(
 }
 
 /// System used by [`ProcGenSimplePlugin`] to run generators and spawn their node's assets
-pub fn generate_and_spawn<C: CoordinateSystem + CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner>(
+pub fn generate_and_spawn<C: CartesianCoordinates, A: AssetsBundleSpawner, T: ComponentSpawner>(
     mut commands: Commands,
     mut pending_generations: ResMut<PendingGenerations>,
     mut generations: Query<(&mut Generator<C>, &AssetSpawner<A, T>)>,

--- a/bevy_ghx_proc_gen/src/lib.rs
+++ b/bevy_ghx_proc_gen/src/lib.rs
@@ -16,7 +16,9 @@ pub use bevy_mod_picking;
 pub use bevy_egui;
 
 use bevy::{ecs::bundle::Bundle, prelude::SpatialBundle};
-use bevy_ghx_grid::ghx_grid::{coordinate_system::CoordinateSystem, cartesian::grid::CartesianGrid};
+use bevy_ghx_grid::ghx_grid::{
+    cartesian::grid::CartesianGrid, coordinate_system::CoordinateSystem,
+};
 use gen::assets::{AssetSpawner, AssetsBundleSpawner, ComponentSpawner};
 use proc_gen::generator::Generator;
 

--- a/bevy_ghx_proc_gen/src/lib.rs
+++ b/bevy_ghx_proc_gen/src/lib.rs
@@ -16,7 +16,7 @@ pub use bevy_mod_picking;
 pub use bevy_egui;
 
 use bevy::{ecs::bundle::Bundle, prelude::SpatialBundle};
-use bevy_ghx_grid::ghx_grid::{coordinate_system::CoordinateSystem, grid::GridDefinition};
+use bevy_ghx_grid::ghx_grid::{coordinate_system::CoordinateSystem, cartesian::grid::CartesianGrid};
 use gen::assets::{AssetSpawner, AssetsBundleSpawner, ComponentSpawner};
 use proc_gen::generator::Generator;
 
@@ -27,8 +27,8 @@ use proc_gen::generator::Generator;
 pub struct GeneratorBundle<C: CoordinateSystem, A: AssetsBundleSpawner, T: ComponentSpawner> {
     /// For positional rendering of the grid
     pub spatial: SpatialBundle,
-    /// Grid definition (Should be the same [`bevy_ghx_grid::ghx_grid::grid::GridDefinition`] as in the generator)
-    pub grid: GridDefinition<C>,
+    /// Grid definition (Should be the same [`bevy_ghx_grid::ghx_grid::grid::CartesianGrid`] as in the generator)
+    pub grid: CartesianGrid<C>,
     /// Generator
     pub generator: Generator<C>,
     /// Assets information used when spawning nodes

--- a/examples/chessboard.rs
+++ b/examples/chessboard.rs
@@ -6,10 +6,7 @@ use ghx_proc_gen::{
         rules::RulesBuilder,
         socket::{SocketCollection, SocketsCartesian2D},
     },
-    ghx_grid::{
-        coordinate_system::Cartesian2D,
-        grid::{GridDefinition, GridPosition},
-    },
+    ghx_grid::cartesian::{coordinates::Cartesian2D, grid::CartesianGrid},
 };
 
 use ghx_proc_gen::generator::builder::GeneratorBuilder;
@@ -36,14 +33,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         .unwrap();
 
     // Like a chess board, let's do an 8x8 2d grid
-    let grid = GridDefinition::new_cartesian_2d(8, 8, false, false);
+    let grid = CartesianGrid::new_cartesian_2d(8, 8, false, false);
+    let initial_nodes = vec![(grid.index_from_coords(0, 0, 0), black_model)];
 
     // There many more parameters you can tweak on a Generator before building it, explore the API.
     let mut generator = GeneratorBuilder::new()
         .with_rules(rules)
         .with_grid(grid)
         // Let's ensure that we make a chessboard, with a black square bottom-left
-        .with_initial_nodes(vec![(GridPosition::new_xy(0, 0), black_model)])?
+        //.with_initial_nodes(vec![(CartesianPosition::new_xy(0, 0), black_model)])?
+        .with_initial_nodes(initial_nodes)?
         .build()?;
 
     // Here we directly generate the whole grid, and ask for the result to be returned.

--- a/examples/unicode-terrain.rs
+++ b/examples/unicode-terrain.rs
@@ -13,8 +13,8 @@ use ghx_proc_gen::{
         GenerationStatus, ModelSelectionHeuristic,
     },
     ghx_grid::{
-        coordinate_system::Cartesian2D,
-        grid::{GridData, GridDefinition},
+        cartesian::{coordinates::Cartesian2D, grid::CartesianGrid},
+        grid::GridData,
     },
 };
 
@@ -85,7 +85,7 @@ fn main() {
     let rules = RulesBuilder::new_cartesian_2d(models, sockets)
         .build()
         .unwrap();
-    let grid = GridDefinition::new_cartesian_2d(35, 12, false, false);
+    let grid = CartesianGrid::new_cartesian_2d(35, 12, false, false);
     let mut generator = GeneratorBuilder::new()
         .with_rules(rules)
         .with_grid(grid)
@@ -132,7 +132,7 @@ fn main() {
 }
 
 fn display_grid(
-    data_grid: &GridData<Cartesian2D, Option<ModelInstance>>,
+    data_grid: &GridData<Cartesian2D, Option<ModelInstance>, CartesianGrid<Cartesian2D>>,
     icons: &Vec<&'static str>,
 ) {
     for y in (0..data_grid.grid().size_y()).rev() {

--- a/ghx_proc_gen/Cargo.toml
+++ b/ghx_proc_gen/Cargo.toml
@@ -23,7 +23,7 @@ reflect = ["bevy", "ghx_grid/reflect"]
 
 [dependencies]
 # Internal dependencies
-ghx_grid = { version = "0.2.0", features = [] }
+ghx_grid = { version = "0.4", features = [] }
 
 # External dependencies
 bitvec = "1.0.1"
@@ -36,4 +36,8 @@ tracing = "0.1.40"
 # Optional dependencies
 
 # Only enabled when the "bevy" feature is enabled
-bevy = { version = "0.13.0", optional = true, default-features = false }
+bevy = { version = "0.14", optional = true, default-features = false, features = [ 
+    "bevy_winit", 
+    "bevy_render",
+    "wayland",
+]}

--- a/ghx_proc_gen/src/generator.rs
+++ b/ghx_proc_gen/src/generator.rs
@@ -5,8 +5,11 @@ use std::{collections::HashMap, sync::Arc};
 use bevy::ecs::component::Component;
 
 use ghx_grid::{
+    cartesian::{
+        coordinates::{Cartesian2D, CartesianCoordinates},
+        grid::CartesianGrid,
+    },
     coordinate_system::CoordinateSystem,
-    cartesian::{coordinates::{Cartesian2D, CartesianCoordinates}, grid::CartesianGrid},
     grid::{GridData, NodeRef},
 };
 
@@ -107,7 +110,7 @@ pub struct Generator<C: CoordinateSystem> {
     internal: InternalGenerator<C>,
 }
 
-impl<C: CoordinateSystem + CartesianCoordinates> Generator<C> {
+impl<C: CartesianCoordinates> Generator<C> {
     /// Returns a new `GeneratorBuilder`
     pub fn builder() -> GeneratorBuilder<Unset, Unset, Cartesian2D> {
         GeneratorBuilder::new()

--- a/ghx_proc_gen/src/generator/builder.rs
+++ b/ghx_proc_gen/src/generator/builder.rs
@@ -1,7 +1,9 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use ghx_grid::{
-    cartesian::{coordinates::CartesianCoordinates, grid::CartesianGrid}, coordinate_system::CoordinateSystem, grid::{GridData, NodeRef},
+    cartesian::{coordinates::CartesianCoordinates, grid::CartesianGrid},
+    coordinate_system::CoordinateSystem,
+    grid::{GridData, NodeRef},
 };
 
 use crate::{GeneratorBuilderError, NodeIndex};
@@ -170,7 +172,7 @@ impl<G, R, C: CoordinateSystem> GeneratorBuilder<G, R, C> {
 }
 
 // For functions in this impl, we know that self.grid is `Some` thanks to the typing.
-impl<C: CoordinateSystem + CartesianCoordinates, R> GeneratorBuilder<Set, R, C> {
+impl<C: CartesianCoordinates, R> GeneratorBuilder<Set, R, C> {
     /// Adds a [`QueuedStatefulObserver`] to the [`Generator`] that will be built, and returns it.
     ///
     /// Adding the observer before building the generator allows the observer to see the nodes than *can* be generated during a generator's initialization.
@@ -218,7 +220,7 @@ impl<C: CoordinateSystem + CartesianCoordinates, R> GeneratorBuilder<Set, R, C> 
 }
 
 // For functions in this impl, we know that self.rules and self.grid are `Some` thanks to the typing.
-impl<C: CoordinateSystem + CartesianCoordinates> GeneratorBuilder<Set, Set, C> {
+impl<C: CartesianCoordinates> GeneratorBuilder<Set, Set, C> {
     /// Registers some [`NodeRef`] [`ModelVariantRef`] pairs to be spawned initially by the [`Generator`]. These nodes will be spawned when the generator reinitializes too.
     ///
     /// See [`GeneratorBuilder::with_initial_nodes_raw`] for a bit more performant but more constrained method. The performance difference only matters during this method call in the `GeneratorBuilder`, during generation all the initial nodes are already converted to their raw format.

--- a/ghx_proc_gen/src/generator/internal_generator.rs
+++ b/ghx_proc_gen/src/generator/internal_generator.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use bitvec::{bitvec, order::LocalBits, slice::IterOnes, vec::BitVec};
 use ghx_grid::{
-    cartesian::{grid::CartesianGrid, coordinates::CartesianCoordinates},
+    cartesian::{coordinates::CartesianCoordinates, grid::CartesianGrid},
     coordinate_system::CoordinateSystem,
-    grid::{GridData, Grid},
     direction::DirectionTrait,
+    grid::GridData,
 };
 use ndarray::{Array, Ix3};
 use rand::{
@@ -70,7 +70,7 @@ pub(crate) struct InternalGenerator<C: CoordinateSystem> {
     supports_count: Array<usize, Ix3>,
 }
 
-impl<C: CoordinateSystem + CartesianCoordinates> InternalGenerator<C> {
+impl<C: CartesianCoordinates> InternalGenerator<C> {
     pub(crate) fn new(
         rules: Arc<Rules<C>>,
         grid: CartesianGrid<C>,
@@ -92,7 +92,7 @@ impl<C: CoordinateSystem + CartesianCoordinates> InternalGenerator<C> {
         let node_selection_heuristic = InternalNodeSelectionHeuristic::from_external(
             node_selection_heuristic,
             &rules,
-            grid.total_size(),
+            nodes_count,
         );
 
         Self {
@@ -118,7 +118,7 @@ impl<C: CoordinateSystem + CartesianCoordinates> InternalGenerator<C> {
     }
 }
 
-impl<C: CoordinateSystem + CartesianCoordinates> InternalGenerator<C> {
+impl<C: CartesianCoordinates> InternalGenerator<C> {
     #[inline]
     fn is_model_possible(&self, node: NodeIndex, model: ModelVariantIndex) -> bool {
         self.nodes[node * self.rules.models_count() + model] == true
@@ -708,8 +708,7 @@ impl<C: CoordinateSystem + CartesianCoordinates> InternalGenerator<C> {
     }
 
     /// Should only be called when the nodes are fully generated
-    pub(crate) fn to_grid_data(&self) -> GridData<C, ModelInstance, CartesianGrid<C>> 
-        {
+    pub(crate) fn to_grid_data(&self) -> GridData<C, ModelInstance, CartesianGrid<C>> {
         let total_size: usize = (self.grid.size_xy() * self.grid.size_z()) as usize;
         let mut generated_nodes = Vec::with_capacity(self.nodes.len());
         //for node_index in 0..self.grid.total_size() {

--- a/ghx_proc_gen/src/generator/internal_generator.rs
+++ b/ghx_proc_gen/src/generator/internal_generator.rs
@@ -80,7 +80,8 @@ impl<C: CoordinateSystem + CartesianCoordinates> InternalGenerator<C> {
         observers: Vec<crossbeam_channel::Sender<GenerationUpdate>>,
     ) -> Self {
         let models_count = rules.models_count();
-        let nodes_count = grid.total_size();
+        //let nodes_count = grid.total_size();
+        let nodes_count: usize = (grid.size_xy() * grid.size_z()) as usize;
         let direction_count = grid.coord_system().directions_count() as usize;
 
         let seed = match rng_mode {
@@ -161,7 +162,8 @@ impl<C: CoordinateSystem + CartesianCoordinates> InternalGenerator<C> {
 
         self.status = InternalGeneratorStatus::Ongoing;
 
-        let nodes_count = self.grid.total_size();
+        //let nodes_count = self.grid.total_size();
+        let nodes_count = (self.grid.size_xy() * self.grid.size_z()) as usize;
         self.nodes = bitvec![1;self.rules.models_count() * nodes_count ];
         self.nodes_left_to_generate = nodes_count;
         self.possible_models_counts = vec![self.rules.models_count(); nodes_count];
@@ -206,7 +208,9 @@ impl<C: CoordinateSystem + CartesianCoordinates> InternalGenerator<C> {
         debug!("Initializing support counts");
 
         let mut neighbours = vec![None; self.grid.coord_system().directions_count()];
-        for node in 0..self.grid.total_size() {
+        let total_size: usize = (self.grid.size_xy() * self.grid.size_z()) as usize;
+        //for node in 0..self.grid.total_size() {
+        for node in 0..total_size {
             // For a given `node`, `neighbours[direction]` will hold the optionnal index of the neighbour node in `direction`
             for direction in self.grid.coord_system().directions() {
                 let grid_pos = self.grid.pos_from_index(node);
@@ -706,9 +710,11 @@ impl<C: CoordinateSystem + CartesianCoordinates> InternalGenerator<C> {
     /// Should only be called when the nodes are fully generated
     pub(crate) fn to_grid_data(&self) -> GridData<C, ModelInstance, CartesianGrid<C>> 
         {
+        let total_size: usize = (self.grid.size_xy() * self.grid.size_z()) as usize;
         let mut generated_nodes = Vec::with_capacity(self.nodes.len());
-        for node_index in 0..self.grid.total_size() {
-            let model_index = self.get_model_index(node_index);
+        //for node_index in 0..self.grid.total_size() {
+        for node_index in 0..total_size {
+            let model_index = self.get_model_index(node_index.try_into().unwrap());
             generated_nodes.push(self.rules.model(model_index).clone())
         }
 

--- a/ghx_proc_gen/src/generator/model.rs
+++ b/ghx_proc_gen/src/generator/model.rs
@@ -1,8 +1,9 @@
 use std::{borrow::Cow, collections::HashSet, fmt, marker::PhantomData};
 
 use ghx_grid::{
-    coordinate_system::{Cartesian2D, Cartesian3D, CoordinateSystem},
-    direction::Direction,
+    cartesian::coordinates::{Cartesian2D, Cartesian3D},
+    coordinate_system::CoordinateSystem,
+    direction::{Direction, DirectionTrait},
 };
 #[cfg(feature = "debug-traces")]
 use tracing::warn;

--- a/ghx_proc_gen/src/generator/observer.rs
+++ b/ghx_proc_gen/src/generator/observer.rs
@@ -3,7 +3,9 @@ use super::{model::ModelInstance, GeneratedNode, Generator};
 #[cfg(feature = "bevy")]
 use bevy::ecs::component::Component;
 use ghx_grid::{
-    cartesian::{coordinates::CartesianCoordinates, grid::CartesianGrid}, coordinate_system::CoordinateSystem, grid::{Grid, GridData}
+    cartesian::{coordinates::CartesianCoordinates, grid::CartesianGrid},
+    coordinate_system::CoordinateSystem,
+    grid::GridData,
 };
 
 /// Update sent by a [`crate::generator::Generator`]
@@ -21,12 +23,12 @@ pub enum GenerationUpdate {
 ///
 /// Can be used in a different thread than the generator's thread.
 #[cfg_attr(feature = "bevy", derive(Component))]
-pub struct QueuedStatefulObserver<C: CoordinateSystem + CartesianCoordinates> {
+pub struct QueuedStatefulObserver<C: CartesianCoordinates> {
     grid_data: GridData<C, Option<ModelInstance>, CartesianGrid<C>>,
     receiver: crossbeam_channel::Receiver<GenerationUpdate>,
 }
 
-impl<C: CoordinateSystem + CartesianCoordinates> QueuedStatefulObserver<C> {
+impl<C: CartesianCoordinates> QueuedStatefulObserver<C> {
     /// Creates a new [`QueuedStatefulObserver`] for a given [`crate::generator::Generator`]
     pub fn new(generator: &mut Generator<C>) -> Self {
         let receiver = generator.create_observer_queue();
@@ -37,8 +39,9 @@ impl<C: CoordinateSystem + CartesianCoordinates> QueuedStatefulObserver<C> {
         receiver: crossbeam_channel::Receiver<GenerationUpdate>,
         grid: &CartesianGrid<C>,
     ) -> Self {
+        let total_size = (grid.size_xy() * grid.size_z()) as usize;
         QueuedStatefulObserver {
-            grid_data: GridData::new(grid.clone(), vec![None; grid.total_size()]),
+            grid_data: GridData::new(grid.clone(), vec![None; total_size]),
             receiver,
         }
     }

--- a/ghx_proc_gen/src/generator/rules.rs
+++ b/ghx_proc_gen/src/generator/rules.rs
@@ -5,8 +5,9 @@ use std::{
 };
 
 use ghx_grid::{
-    coordinate_system::{Cartesian2D, Cartesian3D, CoordinateSystem},
-    direction::Direction,
+    cartesian::coordinates::{Cartesian2D, Cartesian3D},
+    coordinate_system::CoordinateSystem,
+    direction::{Direction, DirectionTrait},
 };
 use ndarray::{Array, Ix1, Ix2};
 
@@ -226,8 +227,8 @@ impl<C: CoordinateSystem> Rules<C> {
             Array::from_elem(coord_system.directions().len(), BTreeSet::new());
         for (model_index, model) in model_variations.iter().enumerate() {
             for &direction in coord_system.directions() {
-                let opposite_dir = direction.opposite() as usize;
-                for socket in &model.sockets()[direction as usize] {
+                let opposite_dir = usize::try_from(direction.opposite()).unwrap();
+                for socket in &model.sockets()[usize::try_from(direction).unwrap()] {
                     let compatible_models = sockets_to_models
                         .entry(socket)
                         .or_insert(empty_in_all_directions.clone());
@@ -245,16 +246,16 @@ impl<C: CoordinateSystem> Rules<C> {
                 // We filter unique models with a Set, but waht we want in the Rules is a Vec for access speed, caching, and iteration determinism.
                 let mut unique_models = HashSet::new();
                 // For each socket of the model in this direction: get all the sockets that are compatible for connection
-                for socket in &model.sockets()[direction as usize] {
+                for socket in &model.sockets()[usize::try_from(direction).unwrap()] {
                     if let Some(compatible_sockets) = socket_collection.get_compatibles(*socket) {
                         for compatible_socket in compatible_sockets {
                             // For each of those: get all the models that have this socket from direction
                             // `sockets_to_models` may not have an entry for `compatible_socket` depending on user input data (socket present in sockets_connections but not in a model)
                             if let Some(allowed_models) = sockets_to_models.get(&compatible_socket)
                             {
-                                for allowed_model in &allowed_models[direction as usize] {
+                                for allowed_model in &allowed_models[usize::try_from(direction).unwrap()] {
                                     if unique_models.insert(*allowed_model) {
-                                        allowed_neighbours[(model_index, direction as usize)]
+                                        allowed_neighbours[(model_index, usize::try_from(direction).unwrap())]
                                             .push(*allowed_model);
                                     }
                                 }

--- a/ghx_proc_gen/src/generator/rules.rs
+++ b/ghx_proc_gen/src/generator/rules.rs
@@ -253,9 +253,12 @@ impl<C: CoordinateSystem> Rules<C> {
                             // `sockets_to_models` may not have an entry for `compatible_socket` depending on user input data (socket present in sockets_connections but not in a model)
                             if let Some(allowed_models) = sockets_to_models.get(&compatible_socket)
                             {
-                                for allowed_model in &allowed_models[usize::try_from(direction).unwrap()] {
+                                for allowed_model in
+                                    &allowed_models[usize::try_from(direction).unwrap()]
+                                {
                                     if unique_models.insert(*allowed_model) {
-                                        allowed_neighbours[(model_index, usize::try_from(direction).unwrap())]
+                                        allowed_neighbours
+                                            [(model_index, usize::try_from(direction).unwrap())]
                                             .push(*allowed_model);
                                     }
                                 }

--- a/ghx_proc_gen/src/generator/socket.rs
+++ b/ghx_proc_gen/src/generator/socket.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use ghx_grid::coordinate_system::{Cartesian2D, Cartesian3D};
+use ghx_grid::cartesian::coordinates::{Cartesian2D, Cartesian3D};
 
 use super::model::{ModelRotation, ModelTemplate, ALL_MODEL_ROTATIONS};
 


### PR DESCRIPTION
What works so far:
Both chessboard examples
Unicode terrain

What doesn't work: 
All Cartesian3D examples 

Possible cause:
Out of Bounds error in internal_generator.rs:660

Note: Everything is only made for Cartesian2D and Cartesian3D, the generator isn't generalized for any Grid< C >
Note2: I needed to add a backend so winit would compile in bevy 0.14, don't know if there is a workaround for libraries

As is you can (probably) use this branch for Cartesian2D generations without issues

EDIT: Found one source of the Cartesian3D not working, total_size() function worked differently in the ghx_grid 0.2 compared to ghx_grid 0.4, don't know if it is a bug or intentional. Now pillars example work but canyon still doesn't