### PR TITLE
Fix bevy_ghx_proc_gen and bevy example compilation

### DIFF
--- a/bevy_examples/Cargo.toml
+++ b/bevy_examples/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["assets/"]
 [dependencies]
 # ----- Internal dependencies
 bevy_ghx_proc_gen = { path = "../bevy_ghx_proc_gen", default-features = true }
-bevy_editor_cam = { version = "0.5.0" }
+bevy_editor_cam = { version = "0.6.0" }
 
 # ----- External dependencies
 tracing-subscriber = "0.3.18"

--- a/bevy_ghx_proc_gen/Cargo.toml
+++ b/bevy_ghx_proc_gen/Cargo.toml
@@ -17,6 +17,7 @@ default = [
     "picking",
     "egui-edit",
     "default-bundle-inserters",
+    "log",
 ]
 # Enables some reflect derives in ghx_proc_gen
 reflect = ["ghx_proc_gen/reflect", "bevy_ghx_grid/reflect"]
@@ -41,6 +42,10 @@ default-bundle-inserters = [
     "bevy/bevy_sprite", # 2D (sprites) rendering
     "bevy/bevy_pbr",    # 3D (physically-based) rendering
     "bevy/bevy_asset",  # Assets management
+]
+# Enables logging using bevy_log
+log = [
+    "bevy/bevy_log" # Logging
 ]
 
 [dependencies]

--- a/bevy_ghx_proc_gen/src/debug_plugin/cursor.rs
+++ b/bevy_ghx_proc_gen/src/debug_plugin/cursor.rs
@@ -14,7 +14,6 @@ use bevy::{
         system::{Commands, Local, Query, Res, ResMut},
     },
     input::{keyboard::KeyCode, ButtonInput},
-    log::warn,
     prelude::{Text, TextUiWriter, Trigger},
     render::camera::Camera,
     text::{LineBreak, TextColor, TextFont, TextLayout, TextSpan},
@@ -23,6 +22,10 @@ use bevy::{
     ui::{BackgroundColor, Node, PositionType, UiRect, Val},
     utils::default,
 };
+
+#[cfg(feature = "log")]
+use bevy::log::warn;
+
 use bevy_ghx_grid::{
     debug_plugin::markers::{spawn_marker, GridMarker, MarkerDespawnEvent},
     ghx_grid::{coordinate_system::CoordinateSystem, direction::Direction},
@@ -716,6 +719,7 @@ pub fn update_cursors_overlays(
             Ok(found) => found,
             Err(_) => {
                 if !camera_warning_flag.0 {
+                    #[cfg(feature = "log")]
                     warn!("None (or too many) Camera(s) found with 'GridCursorsOverlayCamera' component to display cursors overlays. Add `GridCursorsOverlayCamera` component to a Camera or change the cursor UI mode.");
                     camera_warning_flag.0 = true;
                 }

--- a/bevy_ghx_proc_gen/src/debug_plugin/egui_editor.rs
+++ b/bevy_ghx_proc_gen/src/debug_plugin/egui_editor.rs
@@ -8,8 +8,11 @@ use bevy::{
         system::{Query, Res, ResMut},
     },
     input::{mouse::MouseButton, ButtonInput},
-    log::warn,
 };
+
+#[cfg(feature = "log")]
+use bevy::log::warn;
+
 use bevy_egui::{
     egui::{self, Color32, Pos2},
     EguiContexts,
@@ -304,6 +307,7 @@ pub fn paint<C: CartesianCoordinates>(
         };
 
         if let Err(err) = generator.set_and_propagate(node.0, model_brush.instance, true) {
+            #[cfg(feature = "log")]
             warn!(
                 "Failed to generate model {} on node {}: {}",
                 model_brush.instance, node.0, err

--- a/bevy_ghx_proc_gen/src/debug_plugin/generation.rs
+++ b/bevy_ghx_proc_gen/src/debug_plugin/generation.rs
@@ -11,10 +11,13 @@ use bevy::{
         system::{Commands, Query, Res, ResMut},
     },
     input::{keyboard::KeyCode, ButtonInput},
-    log::{info, warn},
     prelude::{Component, Deref, DerefMut, Resource},
     time::{Time, Timer, TimerMode},
 };
+
+#[cfg(feature = "log")]
+use bevy::log::{info, warn};
+
 use bevy_ghx_grid::debug_plugin::markers::{spawn_marker, MarkerDespawnEvent};
 use ghx_proc_gen::{
     generator::{
@@ -236,6 +239,7 @@ pub fn handle_reinitialization_and_continue<C: CartesianCoordinates>(
         match generator.reinitialize() {
             GenerationStatus::Ongoing => (),
             GenerationStatus::Done => {
+                #[cfg(feature = "log")]
                 info!(
                     "Generation done, seed: {}; grid: {}",
                     generator.seed(),
@@ -264,6 +268,7 @@ pub fn handle_generation_done<C: CartesianCoordinates>(
     gen_entity: Entity,
     try_count: u32,
 ) {
+    #[cfg(feature = "log")]
     info!(
         "Generation done {:?}, try_count: {}, seed: {}; grid: {}",
         gen_entity,
@@ -285,6 +290,7 @@ pub fn handle_generation_error<C: CartesianCoordinates>(
     gen_entity: Entity,
     node_index: NodeIndex,
 ) {
+    #[cfg(feature = "log")]
     warn!(
         "Generation Failed {:?} at node {}, seed: {}; grid: {}",
         gen_entity,

--- a/bevy_ghx_proc_gen/src/lib.rs
+++ b/bevy_ghx_proc_gen/src/lib.rs
@@ -14,7 +14,7 @@ use bevy::{
         system::{Commands, Query, Res},
     },
     math::Vec3,
-    platform_support::collections::HashSet,
+    platform::collections::HashSet,
     prelude::{Deref, DerefMut, Without},
 };
 use ghx_proc_gen::{

--- a/bevy_ghx_proc_gen/src/simple_plugin.rs
+++ b/bevy_ghx_proc_gen/src/simple_plugin.rs
@@ -8,10 +8,13 @@ use bevy::{
         schedule::IntoScheduleConfigs,
         system::{Commands, Query, ResMut},
     },
-    log::{info, warn},
     platform::collections::HashSet,
     prelude::Resource,
 };
+
+#[cfg(feature = "log")]
+use bevy::log::{info, warn};
+
 use ghx_proc_gen::{
     generator::Generator,
     ghx_grid::cartesian::{coordinates::CartesianCoordinates, grid::CartesianGrid},
@@ -93,6 +96,7 @@ pub fn generate_and_spawn<C: CartesianCoordinates>(
         if let Ok(mut generation) = generations.get_mut(gen_entity) {
             match generation.generate_grid() {
                 Ok((gen_info, grid_data)) => {
+                    #[cfg(feature = "log")]
                     info!(
                         "Generation {:?} done, try_count: {}, seed: {}; grid: {}",
                         gen_entity,
@@ -104,6 +108,7 @@ pub fn generate_and_spawn<C: CartesianCoordinates>(
                     generations_done.push(gen_entity);
                 }
                 Err(GeneratorError { node_index }) => {
+                    #[cfg(feature = "log")]
                     warn!(
                         "Generation {:?} failed at node {}, seed: {}; grid: {}",
                         gen_entity,

--- a/bevy_ghx_proc_gen/src/simple_plugin.rs
+++ b/bevy_ghx_proc_gen/src/simple_plugin.rs
@@ -9,7 +9,7 @@ use bevy::{
         system::{Commands, Query, ResMut},
     },
     log::{info, warn},
-    platform_support::collections::HashSet,
+    platform::collections::HashSet,
     prelude::Resource,
 };
 use ghx_proc_gen::{

--- a/bevy_ghx_proc_gen/src/spawner_plugin.rs
+++ b/bevy_ghx_proc_gen/src/spawner_plugin.rs
@@ -9,7 +9,7 @@ use bevy::{
         world::OnAdd,
     },
     math::Vec3,
-    platform_support::collections::HashSet,
+    platform::collections::HashSet,
     prelude::{Children, Entity, Trigger, With},
     render::view::Visibility,
 };


### PR DESCRIPTION
I ran into some trouble running the bevy examples due to some upstream changes in both bevy and bevy_editor_cam.

* `bevy::platform_support` was renamed to `bevy::platform`: bevyengine/bevy#18813
* `bevy::log` wasn't resolving without enabling Bevy's `bevy_log` feature, I believe because of the revert in bevyengine/bevy#18816.
  * I put the usage of bevy_log behind a cargo feature called "log" in case it's desired to be optional.
* The compiler could not find an impl of the `bevy::ecs::bundle::Bundle` trait for `bevy_editor_cam::EditorCam`. Bumping the version of [bevy_editor_cam](https://github.com/aevyrie/bevy_editor_cam) to 0.6.0 fixed this.

After these changes, the examples all compile and run. I also considered bumping bevy to 0.16.1, which also worked fine, but left that out of this PR.